### PR TITLE
Django 1.11 Compatibility

### DIFF
--- a/cached_modelforms/forms.py
+++ b/cached_modelforms/forms.py
@@ -11,7 +11,10 @@ from __future__ import unicode_literals
 from collections import OrderedDict
 
 from django.utils.text import capfirst
-from django.forms.utils import ErrorList
+try:
+    from django.forms.utils import ErrorList
+except ImportError:
+    from django.forms.util import ErrorList
 from django.core.exceptions import FieldError
 from django.forms.widgets import media_property
 from django.db.models import ForeignKey, ManyToManyField

--- a/cached_modelforms/forms.py
+++ b/cached_modelforms/forms.py
@@ -8,17 +8,51 @@ fields.py
 
 from __future__ import unicode_literals
 
+from collections import OrderedDict
+
 from django.utils.text import capfirst
-from django.forms.util import ErrorList
+from django.forms.utils import ErrorList
 from django.core.exceptions import FieldError
 from django.forms.widgets import media_property
 from django.db.models import ForeignKey, ManyToManyField
-from django.forms.forms import BaseForm, get_declared_fields
+from django.forms.fields import Field
+from django.forms.forms import BaseForm
 from django.forms.models import BaseModelForm, ModelFormOptions, fields_for_model
 
-from six import with_metaclass
+from six import with_metaclass, iteritems
 
 from .fields import CachedModelChoiceField, CachedModelMultipleChoiceField
+
+
+def get_declared_fields(bases, attrs, with_base_fields=True):
+    """
+    Create a list of form field instances from the passed in 'attrs', plus any
+    similar fields on the base classes (in 'bases'). This is used by both the
+    Form and ModelForm metaclasses.
+    If 'with_base_fields' is True, all fields from the bases are used.
+    Otherwise, only fields in the 'declared_fields' attribute on the bases are
+    used. The distinction is useful in ModelForm subclassing.
+    Also integrates any additional media definitions.
+    """
+    fields = [
+        (field_name, attrs.pop(field_name))
+        for field_name, obj in list(iteritems(attrs)) if isinstance(obj, Field)
+    ]
+    fields.sort(key=lambda x: x[1].creation_counter)
+
+    # If this class is subclassing another Form, add that Form's fields.
+    # Note that we loop over the bases in *reverse*. This is necessary in
+    # order to preserve the correct order of fields.
+    if with_base_fields:
+        for base in bases[::-1]:
+            if hasattr(base, 'base_fields'):
+                fields = list(iteritems(base.base_fields)) + fields
+    else:
+        for base in bases[::-1]:
+            if hasattr(base, 'declared_fields'):
+                fields = list(iteritems(base.declared_fields)) + fields
+
+    return OrderedDict(fields)
 
 
 def make_formfield_callback(another_func, objects):


### PR DESCRIPTION
This commit updates a reference and provides an implementation for the since-removed `get_declared_fields` to make things work with Django 1.11 (and hopefully 1.9+).